### PR TITLE
Pin litellm below 1.82.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,12 @@ server = [
     "uvicorn>=0.22",
 ]
 litellm = [
-    "litellm>=1.50,<2.0",
+    "litellm>=1.50,<=1.82.6",
     "fastapi>=0.100",
     "uvicorn>=0.22",
 ]
 training = [
-    "litellm>=1.50,<2.0",
+    "litellm>=1.50,<=1.82.6",
 ]
 prefill = [
     "torch>=2.0",
@@ -51,7 +51,7 @@ prefill = [
     "tqdm>=4.60",
 ]
 proxy = [
-    "litellm[proxy]>=1.50,<2.0",
+    "litellm[proxy]>=1.50,<=1.82.6",
     "packaging>=20.0",
 ]
 dev = [


### PR DESCRIPTION
LiteLLM 1.82.7 has a critical vulnerability: https://github.com/BerriAI/litellm/issues/24512