### PR TITLE
feat(proxy): inject routing strategy at startup and add model_group_a…

### DIFF
--- a/src/model_router_toolkit/adapters/litellm/config_bridge.py
+++ b/src/model_router_toolkit/adapters/litellm/config_bridge.py
@@ -48,11 +48,18 @@ def generate_litellm_config(
         }
         model_list.append(entry)
 
+    first_model_name = config.models[0].name if config.models else None
+    router_settings: dict[str, Any] = {
+        "routing_strategy": "simple-shuffle",
+    }
+    if first_model_name:
+        router_settings["model_group_alias"] = {
+            "nvidia-routed": first_model_name,
+        }
+
     litellm_config: dict[str, Any] = {
         "model_list": model_list,
-        "router_settings": {
-            "routing_strategy": "simple-shuffle",
-        },
+        "router_settings": router_settings,
     }
 
     if output:

--- a/src/model_router_toolkit/adapters/litellm/proxy.py
+++ b/src/model_router_toolkit/adapters/litellm/proxy.py
@@ -106,26 +106,22 @@ def start_proxy(
 
     from litellm.proxy.proxy_server import app as litellm_app
 
-    _strategy_injected = False
     _strategy_ref = None
 
-    class _RouterProxyMiddleware(BaseHTTPMiddleware):
-        """Two responsibilities:
+    @litellm_app.on_event("startup")
+    async def _inject_routing_strategy():
+        nonlocal _strategy_ref
+        try:
+            _strategy_ref = _inject_strategy(router_config_abs)
+        except Exception:
+            logger.exception("Failed to inject routing strategy at startup")
 
-        1. Inject routing strategy on the first request (litellm's lifespan
-           ignores on_event("startup"), so we inject here instead).
-        2. Patch the response ``model`` field to reflect the actual routed
-           model (litellm echoes the request model name, not the deployment).
+    class _RouterProxyMiddleware(BaseHTTPMiddleware):
+        """Patch the response ``model`` field to reflect the actual routed
+        model (litellm echoes the request model name, not the deployment).
         """
 
         async def dispatch(self, request: Request, call_next) -> Response:
-            nonlocal _strategy_injected, _strategy_ref
-            if not _strategy_injected:
-                _strategy_injected = True
-                try:
-                    _strategy_ref = _inject_strategy(router_config_abs)
-                except Exception:
-                    logger.exception("Failed to inject routing strategy")
 
             response = await call_next(request)
 


### PR DESCRIPTION
…lias

Two changes to improve NemoClaw integration:

1. Inject the routing strategy eagerly at startup via on_event("startup") instead of lazily on the first request. This fixes a 400 error when the first request uses a virtual model name (e.g., "nvidia-routed") that only becomes valid after the strategy is registered.

2. Add model_group_alias to the generated LiteLLM proxy config so callers can use "nvidia-routed" as the model name. LiteLLM maps it to the first pool model, and the routing strategy overrides the selection.