### PR TITLE
chore: migrate helm examples from llama-3.1-405b to llama-4-maverick-…

### DIFF
--- a/deploy/helm/llm-router/README.md
+++ b/deploy/helm/llm-router/README.md
@@ -50,8 +50,8 @@ kubectl create secret generic multi-provider-keys \
 routerController:
   config:
     models:
-      brainstorming: "meta/llama-3.1-405b-instruct"  # Upgrade to larger model
-      creativity: "meta/llama-3.1-405b-instruct"     # Upgrade to larger model
+      brainstorming: "meta/llama-4-maverick-17b-128e-instruct"  # Upgrade to larger model
+      creativity: "meta/llama-4-maverick-17b-128e-instruct"     # Upgrade to larger model
 ```
 
 **Custom secret configuration:**
@@ -78,7 +78,7 @@ routerController:
             - name: Brainstorming
               api_base: http://your-local-llm-service:8000/v1
               api_key: ${NVIDIA_API_KEY}
-              model: meta/llama-3.1-405b-instruct
+              model: meta/llama-4-maverick-17b-128e-instruct
 ```
 
 **External ConfigMap:**

--- a/deploy/helm/llm-router/examples/values-local.yaml
+++ b/deploy/helm/llm-router/examples/values-local.yaml
@@ -12,7 +12,7 @@ routerController:
             - name: Brainstorming
               api_base: http://your-local-llm-service:8000/v1
               api_key: ${NVIDIA_API_KEY}
-              model: meta/llama-3.1-405b-instruct
+              model: meta/llama-4-maverick-17b-128e-instruct
             - name: Chatbot
               api_base: http://your-local-llm-service:8000/v1
               api_key: ${NVIDIA_API_KEY}
@@ -63,7 +63,7 @@ routerController:
             - name: Creativity
               api_base: http://your-local-llm-service:8000/v1
               api_key: ${NVIDIA_API_KEY}
-              model: meta/llama-3.1-405b-instruct
+              model: meta/llama-4-maverick-17b-128e-instruct
             - name: Reasoning
               api_base: http://your-local-llm-service:8000/v1
               api_key: ${NVIDIA_API_KEY}

--- a/deploy/helm/llm-router/examples/values-templated-cloud.yaml
+++ b/deploy/helm/llm-router/examples/values-templated-cloud.yaml
@@ -8,7 +8,7 @@ routerController:
     apiBase: "https://integrate.api.nvidia.com"
     models:
       # Task router models
-      brainstorming: "meta/llama-3.1-405b-instruct"  # Use larger model for brainstorming
+      brainstorming: "meta/llama-4-maverick-17b-128e-instruct"  # Use larger model for brainstorming
       chatbot: "mistralai/mixtral-8x22b-instruct-v0.1"
       classification: "meta/llama-3.1-8b-instruct"
       closedQA: "meta/llama-3.1-70b-instruct"
@@ -22,7 +22,7 @@ routerController:
       unknown: "meta/llama-3.1-8b-instruct"
       
       # Complexity router models
-      creativity: "meta/llama-3.1-405b-instruct"  # Use larger model for creativity
+      creativity: "meta/llama-4-maverick-17b-128e-instruct"  # Use larger model for creativity
       reasoning: "nvidia/llama-3.3-nemotron-super-49b-v1"
       contextualKnowledge: "meta/llama-3.1-70b-instruct" 
       fewShot: "meta/llama-3.1-70b-instruct"

--- a/deploy/helm/llm-router/values.override.yaml.sample
+++ b/deploy/helm/llm-router/values.override.yaml.sample
@@ -81,8 +81,8 @@ routerController:
   # Option 3: Custom models (while keeping NVIDIA Cloud API)
   # config:
   #   models:
-  #     brainstorming: "meta/llama-3.1-405b-instruct"
-  #     creativity: "meta/llama-3.1-405b-instruct"
+  #     brainstorming: "meta/llama-4-maverick-17b-128e-instruct"
+  #     creativity: "meta/llama-4-maverick-17b-128e-instruct"
   
   # Option 4: Custom environment variables for local LLMs or multiple providers
   # env:


### PR DESCRIPTION
…17b-128e

Replaces all `meta/llama-3.1-405b-instruct` references in the Helm chart README, example values files, and override sample with `meta/llama-4-maverick-17b-128e-instruct` ahead of 405B deprecation.

Files affected:
- deploy/helm/llm-router/README.md (3 lines: brainstorming, creativity, Brainstorming inline example)
- deploy/helm/llm-router/examples/values-local.yaml (Brainstorming, Creativity local-deploy roles)
- deploy/helm/llm-router/examples/values-templated-cloud.yaml (brainstorming, creativity templated cloud roles)
- deploy/helm/llm-router/values.override.yaml.sample (commented-out example block)

These are documentation/template values consumed by users who copy them as the starting point for self-hosted router deployments. After 405B deprecation in the API catalog, the prior values would 404 on new deployments.