### PR TITLE
Harden playground streaming for reasoning chunks

### DIFF
--- a/src/model_router_toolkit/adapters/litellm/chat.py
+++ b/src/model_router_toolkit/adapters/litellm/chat.py
@@ -18,6 +18,68 @@ def _sse_event(event: str, data: Any) -> str:
     return f"event: {event}\ndata: {payload}\n\n"
 
 
+def _get_field(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _text_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = [_text_value(item) for item in value]
+        return "".join(part for part in parts if part)
+    if isinstance(value, dict):
+        for key in ("text", "content", "reasoning", "reasoning_content"):
+            text = _text_value(value.get(key))
+            if text:
+                return text
+    return ""
+
+
+def _first_choice(chunk: Any) -> Any:
+    choices = _get_field(chunk, "choices")
+    if not choices:
+        return None
+    return choices[0]
+
+
+def _delta_texts(chunk: Any) -> tuple[str, str]:
+    choice = _first_choice(chunk)
+    if choice is None:
+        return "", ""
+
+    delta = _get_field(choice, "delta")
+    if delta is None:
+        return "", ""
+
+    content = _text_value(_get_field(delta, "content"))
+
+    reasoning = (
+        _text_value(_get_field(delta, "reasoning_content"))
+        or _text_value(_get_field(delta, "reasoning"))
+    )
+
+    provider_fields = _get_field(delta, "provider_specific_fields")
+    if not reasoning and provider_fields:
+        reasoning = (
+            _text_value(_get_field(provider_fields, "reasoning_content"))
+            or _text_value(_get_field(provider_fields, "reasoning"))
+        )
+
+    additional_kwargs = _get_field(delta, "additional_kwargs")
+    if not reasoning and additional_kwargs:
+        reasoning = (
+            _text_value(_get_field(additional_kwargs, "reasoning_content"))
+            or _text_value(_get_field(additional_kwargs, "reasoning"))
+        )
+
+    return content, reasoning
+
+
 class ChatRequest(BaseModel):
     message: str
     tolerance: float = 0.10
@@ -70,16 +132,16 @@ async def _chat_stream(request: Request, req: ChatRequest):
             stream=True,
         )
         async for chunk in stream:
-            if chunk.choices:
-                delta = chunk.choices[0].delta
-                content = getattr(delta, "content", None) or ""
-                if content:
-                    yield _sse_event("token", {"text": content})
-                    tokens_sent = True
+            content, reasoning = _delta_texts(chunk)
+            if reasoning:
+                yield _sse_event("reasoning", {"text": reasoning})
+                tokens_sent = True
+            if content:
+                yield _sse_event("token", {"text": content})
+                tokens_sent = True
     except Exception as e:
-        if not tokens_sent:
-            yield _sse_event("error", {"message": str(e)[:300]})
-            return
+        yield _sse_event("error", {"message": str(e)[:300], "partial": tokens_sent})
+        return
 
     latency_ms = (time.perf_counter() - t0) * 1000
     yield _sse_event("done", {"latency_ms": round(latency_ms, 2)})

--- a/src/model_router_toolkit/adapters/litellm/static/playground.js
+++ b/src/model_router_toolkit/adapters/litellm/static/playground.js
@@ -346,6 +346,20 @@ const Playground = (function () {
         body: JSON.stringify(payload),
       });
 
+      if (!resp.ok) {
+        var errorText = '';
+        try {
+          errorText = await resp.text();
+        } catch (e) {
+          errorText = resp.statusText || 'Unknown error';
+        }
+        throw new Error('Request failed (' + resp.status + '): ' + (errorText || resp.statusText || 'Unknown error'));
+      }
+
+      if (!resp.body) {
+        throw new Error('Streaming response body was empty');
+      }
+
       typingDiv.remove();
 
       assistantDiv = document.createElement('div');

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -695,6 +695,85 @@ class TestChatEndpoint:
         assert "Hello world" in body
         assert "event: done" in body
 
+    def test_chat_streams_reasoning_only_chunks(self):
+        app = _make_test_app()
+        client = TestClient(app)
+        litellm_router = app.state.litellm_router
+
+        chunk = {"choices": [{"delta": {"reasoning_content": "thinking..."}}]}
+
+        async def mock_stream(**kwargs):
+            class AsyncChunks:
+                def __init__(self):
+                    self._items = [chunk]
+                    self._idx = 0
+
+                def __aiter__(self):
+                    return self
+
+                async def __anext__(self):
+                    if self._idx >= len(self._items):
+                        raise StopAsyncIteration
+                    item = self._items[self._idx]
+                    self._idx += 1
+                    return item
+
+            return AsyncChunks()
+
+        with patch.object(litellm_router, "acompletion", side_effect=mock_stream):
+            resp = client.post(
+                "/api/chat",
+                json={"message": "show your reasoning", "tolerance": 0.15},
+            )
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "event: routing" in body
+        assert "event: reasoning" in body
+        assert "thinking..." in body
+        assert "event: done" in body
+
+    def test_chat_mid_stream_error_is_reported_after_tokens(self):
+        app = _make_test_app()
+        client = TestClient(app)
+        litellm_router = app.state.litellm_router
+
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta = MagicMock()
+        chunk.choices[0].delta.content = "partial answer"
+
+        async def mock_stream(**kwargs):
+            class FailingChunks:
+                def __init__(self):
+                    self._idx = 0
+
+                def __aiter__(self):
+                    return self
+
+                async def __anext__(self):
+                    if self._idx == 0:
+                        self._idx += 1
+                        return chunk
+                    raise RuntimeError("provider stream failed")
+
+            return FailingChunks()
+
+        with patch.object(litellm_router, "acompletion", side_effect=mock_stream):
+            resp = client.post(
+                "/api/chat",
+                json={"message": "test", "tolerance": 0.10},
+            )
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "event: routing" in body
+        assert "event: token" in body
+        assert "partial answer" in body
+        assert "event: error" in body
+        assert "provider stream failed" in body
+        assert "event: done" not in body
+
     def test_chat_tolerance_is_applied(self):
         app = _make_test_app()
         client = TestClient(app)

--- a/tests/integration/test_openclaw_sidecar.py
+++ b/tests/integration/test_openclaw_sidecar.py
@@ -6,7 +6,7 @@ pytest.importorskip("fastapi")
 
 from unittest.mock import patch
 
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from model_router_toolkit.adapters.http.app import create_app
 
@@ -50,6 +50,10 @@ class FakeRouter:
         pass
 
 
+def _test_client(app):
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
 @pytest.mark.asyncio
 class TestOpenClawSidecar:
     """Tests mimicking how the OpenClaw TS plugin calls the sidecar."""
@@ -60,7 +64,7 @@ class TestOpenClawSidecar:
             return_value=FakeRouter(),
         ):
             app = create_app(fake_config_path, warmup=False)
-            async with AsyncClient(app=app, base_url="http://test") as client:
+            async with _test_client(app) as client:
                 resp = await client.post(
                     "/v1/route",
                     json={
@@ -80,7 +84,7 @@ class TestOpenClawSidecar:
             return_value=FakeRouter(),
         ):
             app = create_app(fake_config_path, warmup=False)
-            async with AsyncClient(app=app, base_url="http://test") as client:
+            async with _test_client(app) as client:
                 resp = await client.post(
                     "/v1/route",
                     json={
@@ -97,7 +101,7 @@ class TestOpenClawSidecar:
             return_value=FakeRouter(),
         ):
             app = create_app(fake_config_path, warmup=False)
-            async with AsyncClient(app=app, base_url="http://test") as client:
+            async with _test_client(app) as client:
                 resp = await client.get("/health")
                 assert resp.status_code == 200
                 assert resp.json()["mode"] == "router-only"
@@ -109,7 +113,7 @@ class TestOpenClawSidecar:
             return_value=FakeRouter(),
         ):
             app = create_app(fake_config_path, warmup=False)
-            async with AsyncClient(app=app, base_url="http://test") as client:
+            async with _test_client(app) as client:
                 resp = await client.post("/v1/route", json={"question": "test"})
                 data = resp.json()
                 assert "selected_model" in data


### PR DESCRIPTION
## Summary
- Normalize LiteLLM streaming chunks across object/dict-shaped provider responses
- Emit `reasoning` SSE events for reasoning-only chunks
- Preserve normal `token` streaming for `delta.content`
- Surface provider errors even after partial streamed output
- Show non-200 `/api/chat` failures in the Playground UI
- Update OpenClaw sidecar tests for current `httpx` ASGI transport

## Tests
- `python -m pytest tests/integration/test_litellm_integration.py -q`
- `python -m pytest tests/integration/test_openclaw_sidecar.py tests/integration/test_litellm_integration.py -q`
- `python -m pytest -q`
- `python -m ruff check src/model_router_toolkit/adapters/litellm/chat.py tests/integration/test_litellm_integration.py tests/integration/test_openclaw_sidecar.py`
- `node --check src/model_router_toolkit/adapters/litellm/static/playground.js`

Result: `233 passed, 30 skipped`