### PR TITLE
Honor device detection in serving scorer and harden batched extraction

### DIFF
--- a/src/model_router_toolkit/prefill/extract.py
+++ b/src/model_router_toolkit/prefill/extract.py
@@ -194,6 +194,9 @@ class PrefillExtractor:
         )
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
+        # extract_batch slices hs[:seq_len] and takes hs[-1] as the last
+        # token, which requires real tokens at the front of each row.
+        self._tokenizer.padding_side = "right"
 
         load_kwargs: dict[str, Any] = {
             "dtype": self._dtype,
@@ -306,8 +309,9 @@ class PrefillExtractor:
                     all_mean[li].append(hs.mean(dim=0).cpu())
 
             del outputs, hidden_states, input_ids, attention_mask
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         return PrefillResult(
             hidden_last={li: torch.stack(all_last[li]) for li in layers},

--- a/src/model_router_toolkit/prefill/scorer.py
+++ b/src/model_router_toolkit/prefill/scorer.py
@@ -13,7 +13,7 @@ from typing import Any
 import numpy as np
 import torch
 
-from model_router_toolkit.prefill.extract import PrefillExtractor, PrefillResult
+from model_router_toolkit.prefill.extract import PrefillExtractor, PrefillResult, detect_device
 from model_router_toolkit.prefill.transforms import build_features
 from model_router_toolkit.prefill.trunk import SharedTrunkNet, predict_proba, reconstruct_trunk
 from model_router_toolkit.router import CostEstimate
@@ -36,7 +36,7 @@ class PrefillScorer:
         self._trunk_nets: list[SharedTrunkNet] = []
         self._extractor: PrefillExtractor | None = None
         self.model_names: list[str] = []
-        self._device = "cpu"
+        self._device = detect_device()
 
     def _ensure_loaded(self) -> None:
         if self._ckpt is not None:

--- a/tests/integration/test_prefill_pipeline.py
+++ b/tests/integration/test_prefill_pipeline.py
@@ -5,6 +5,7 @@ and a trained checkpoint. Run with: pytest --run-slow
 """
 
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -94,6 +95,53 @@ class TestPrefillResultSerialization:
         for li in layers:
             torch.testing.assert_close(original.hidden_last[li], loaded.hidden_last[li])
             torch.testing.assert_close(original.hidden_mean[li], loaded.hidden_mean[li])
+
+
+class TestScorerDeviceSelection:
+    """The scorer must honor device auto-detection and ROUTER_DEVICE."""
+
+    def test_scorer_honors_router_device_env(self, monkeypatch):
+        from model_router_toolkit.prefill.scorer import PrefillScorer
+
+        monkeypatch.setenv("ROUTER_DEVICE", "cpu")
+        scorer = PrefillScorer("nonexistent.pt")
+        assert scorer._device == "cpu"
+
+    def test_scorer_auto_detects_cuda(self, monkeypatch):
+        from model_router_toolkit.prefill.scorer import PrefillScorer
+
+        monkeypatch.delenv("ROUTER_DEVICE", raising=False)
+        with patch("torch.cuda.is_available", return_value=True):
+            scorer = PrefillScorer("nonexistent.pt")
+        assert scorer._device == "cuda"
+
+    def test_scorer_matches_detect_device(self, monkeypatch):
+        from model_router_toolkit.prefill.scorer import PrefillScorer
+
+        monkeypatch.delenv("ROUTER_DEVICE", raising=False)
+        scorer = PrefillScorer("nonexistent.pt")
+        assert scorer._device == detect_device()
+
+
+class TestTokenizerPadding:
+    def test_padding_side_forced_right(self):
+        tok = MagicMock()
+        tok.pad_token = "<pad>"
+        tok.padding_side = "left"
+
+        model = MagicMock()
+        model.config.num_hidden_layers = 24
+        model.config.hidden_size = 64
+        model.eval.return_value = model
+
+        with (
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=tok),
+            patch("transformers.AutoModelForCausalLM.from_pretrained", return_value=model),
+        ):
+            extractor = PrefillExtractor("fake/encoder", device="cpu")
+            extractor._ensure_loaded()
+
+        assert extractor._tokenizer.padding_side == "right"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- `PrefillScorer` now selects its device via `detect_device()` instead of a hardcoded `"cpu"`
- Force `padding_side="right"` on the extraction tokenizer to protect last-token hidden-state slicing
- Move `torch.cuda.empty_cache()` out of the per-batch extraction loop

## Issue
The serving path (`serve`, `serve-router` sidecar, proxy) constructed `PrefillScorer` with `device="cpu"` hardcoded, so the encoder prefill forward pass ran on CPU even on GPU hosts. The `ROUTER_DEVICE` environment variable — documented in the README for serve/sidecar/proxy modes — had no effect at inference time, while training and evaluation already auto-detect correctly. On GPU machines this is a large per-request routing latency difference.

Separately, `extract_batch` slices `hs[:seq_len]` and takes `hs[-1]` as the last-token hidden state, which assumes right padding — but `padding_side` was never set, inheriting whatever the encoder's tokenizer config specifies. A left-padding tokenizer silently yields pad-token features during batched (training) extraction while single-question inference is unaffected, producing a train/serve feature mismatch that degrades AUC with no error.

## Changes
- `prefill/scorer.py`: `self._device = detect_device()` (honors `ROUTER_DEVICE`, falls back to cuda/mps/cpu auto-detection); trunk ensemble and extractor follow the detected device
- `prefill/extract.py`: set `tokenizer.padding_side = "right"` in `_ensure_loaded()`; call `torch.cuda.empty_cache()` once after the extraction loop instead of every batch
- Tests: device selection honors `ROUTER_DEVICE`, auto-detects CUDA, matches `detect_device()`; tokenizer padding is forced right even when the encoder config pads left

## Tests
- `python -m pytest tests/integration/test_prefill_pipeline.py -q -k "DeviceSelection or TokenizerPadding"` — 4 passed
- `python -m pytest -q` — 229 passed, 30 skipped; the 6 failures are pre-existing on `v3` (4 are the httpx `ASGITransport` incompatibility addressed by #26, plus environment-specific `test_gpu`/`test_trunk` failures reproducible on a clean checkout)
- `python -m ruff check` on changed files — clean
