### PR TITLE
Sanitize playground output, unblock event loop, scope routing result per request

### DIFF
--- a/src/model_router_toolkit/adapters/http/route.py
+++ b/src/model_router_toolkit/adapters/http/route.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -83,7 +84,10 @@ async def route(request: Request, req: RouteRequest):
     allowed = req.models or getattr(request.app.state, "allowed_models", None)
 
     t0 = time.perf_counter()
-    result = app_router.route(question, tolerance=req.tolerance, models=allowed)
+    # The route call runs encoder inference; keep it off the event loop.
+    result = await asyncio.to_thread(
+        app_router.route, question, tolerance=req.tolerance, models=allowed
+    )
     route_ms = (time.perf_counter() - t0) * 1000
 
     from model_router_toolkit import telemetry

--- a/src/model_router_toolkit/adapters/litellm/chat.py
+++ b/src/model_router_toolkit/adapters/litellm/chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from typing import Any
@@ -34,7 +35,9 @@ async def _chat_stream(request: Request, req: ChatRequest):
     messages = [{"role": "user", "content": req.message}]
 
     t0 = time.perf_counter()
-    result = strategy.router.route(
+    # The route call runs encoder inference; keep it off the event loop.
+    result = await asyncio.to_thread(
+        strategy.router.route,
         req.message,
         tolerance=tolerance,
         models=req.enabled_models,

--- a/src/model_router_toolkit/adapters/litellm/completions.py
+++ b/src/model_router_toolkit/adapters/litellm/completions.py
@@ -23,6 +23,7 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
     temperature = body.get("temperature", 0.7)
     max_tokens = body.get("max_tokens", 4096)
 
+    strategy.begin_request()
     if "tolerance" in body:
         strategy.set_request_tolerance(float(body.get("tolerance", 0.20)))
 

--- a/src/model_router_toolkit/adapters/litellm/proxy.py
+++ b/src/model_router_toolkit/adapters/litellm/proxy.py
@@ -100,11 +100,10 @@ def start_proxy(
 
     os.environ["CONFIG_FILE_PATH"] = litellm_config
 
+    from litellm.proxy.proxy_server import app as litellm_app
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.requests import Request
     from starlette.responses import Response
-
-    from litellm.proxy.proxy_server import app as litellm_app
 
     _strategy_ref = None
 
@@ -122,10 +121,11 @@ def start_proxy(
         """
 
         async def dispatch(self, request: Request, call_next) -> Response:
+            strategy = _strategy_ref
+            if strategy is not None:
+                strategy.begin_request()
 
             response = await call_next(request)
-
-            strategy = _strategy_ref
             if strategy and hasattr(strategy, "last_result") and strategy.last_result:
                 selected = strategy.last_result.selected_model
                 response.headers["X-Model-Router-Selected"] = selected

--- a/src/model_router_toolkit/adapters/litellm/static/index.html
+++ b/src/model_router_toolkit/adapters/litellm/static/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Model Router Toolkit — Playground</title>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <link rel="stylesheet" href="/playground.css">
 </head>
 <body>

--- a/src/model_router_toolkit/adapters/litellm/static/playground.js
+++ b/src/model_router_toolkit/adapters/litellm/static/playground.js
@@ -36,6 +36,27 @@ const Playground = (function () {
 
   function scrollToBottom() { messagesEl.scrollTop = messagesEl.scrollHeight; }
 
+  // Escape untrusted text (model output, judge verdicts, names) before
+  // interpolating into HTML strings.
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // Render markdown sanitized; fall back to plain text if either CDN
+  // library failed to load so model output is never injected raw.
+  function renderMarkdown(el, text) {
+    if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+      el.innerHTML = DOMPurify.sanitize(marked.parse(text));
+    } else {
+      el.textContent = text;
+    }
+  }
+
   // ── Initialization ────────────────────────────────────────────────────
   async function init() {
     await Promise.all([loadConfig(), loadModels()]);
@@ -114,12 +135,12 @@ const Playground = (function () {
     var container = document.getElementById('modelToggles');
     container.innerHTML = models.map(function (m) {
       var outCost = (m.cost_per_m_output_tokens || 0).toFixed(2);
-      return '<div class="model-toggle" data-model="' + m.name + '">' +
+      return '<div class="model-toggle" data-model="' + esc(m.name) + '">' +
         '<label class="toggle-switch">' +
-        '<input type="checkbox" checked data-model="' + m.name + '">' +
+        '<input type="checkbox" checked data-model="' + esc(m.name) + '">' +
         '<span class="toggle-slider"></span></label>' +
         '<div class="model-toggle-info">' +
-        '<div class="model-toggle-name">' + (m.display_name || m.name) + '</div>' +
+        '<div class="model-toggle-name">' + esc(m.display_name || m.name) + '</div>' +
         '<div class="model-toggle-cost">$' + outCost + '/M output</div>' +
         '</div></div>';
     }).join('');
@@ -208,9 +229,9 @@ const Playground = (function () {
       var cls = 'pipeline-step' + (s.active ? ' active' : ' pending');
       if (s.isTtft) cls += ' pipeline-ttft-step';
       html += '<div class="' + cls + '">';
-      html += '<div class="pipeline-step-label">' + s.label + '</div>';
-      html += '<div class="pipeline-step-value' + (s.isTtft ? ' pipeline-ttft-value' : '') + '">' + s.value + '</div>';
-      html += '<div class="pipeline-step-detail">' + s.detail + '</div>';
+      html += '<div class="pipeline-step-label">' + esc(s.label) + '</div>';
+      html += '<div class="pipeline-step-value' + (s.isTtft ? ' pipeline-ttft-value' : '') + '">' + esc(s.value) + '</div>';
+      html += '<div class="pipeline-step-detail">' + esc(s.detail) + '</div>';
       html += '</div>';
     });
     html += '</div>';
@@ -271,7 +292,7 @@ const Playground = (function () {
       else marker = '<span class="prob-marker"></span>';
 
       probsHtml += '<div class="prob-row" style="' + (enabled ? '' : 'opacity:0.35') + '">' +
-        '<span class="prob-name">' + dn(name) + '</span>' +
+        '<span class="prob-name">' + esc(dn(name)) + '</span>' +
         '<span class="prob-value">' + prob.toFixed(3) + '</span>' +
         '<div class="prob-bar-track"><div class="prob-bar-fill" style="width:' + pct + '%"></div></div>' +
         marker + '</div>';
@@ -283,7 +304,7 @@ const Playground = (function () {
       '<div class="routing-header">' +
       '<div class="routing-badge">' +
       '<span class="dot"></span>' +
-      '<span class="model-name">' + dn(selected) + '</span>' +
+      '<span class="model-name">' + esc(dn(selected)) + '</span>' +
       '<span class="cost">' + costStr + '</span>' +
       '<span class="latency">' + routeMs + '</span>' +
       '</div>' +
@@ -294,7 +315,7 @@ const Playground = (function () {
       '<div style="margin-top:8px;">' +
       '<div style="margin-bottom:4px; font-size:10px; color:var(--text-dim);">\u2605 = highest probability, \u2190 = selected model</div>' +
       probsHtml +
-      '<div class="routing-summary"><strong>Selected: ' + dn(selected) + '</strong> \u2014 most efficient model with p(correct) \u2265 ' + thresholdStr + '</div>' +
+      '<div class="routing-summary"><strong>Selected: ' + esc(dn(selected)) + '</strong> \u2014 most efficient model with p(correct) \u2265 ' + thresholdStr + '</div>' +
       '</div></div></div>';
   }
 
@@ -421,7 +442,7 @@ const Playground = (function () {
           assistantDiv.appendChild(contentEl);
         }
         contentText += data.text;
-        contentEl.innerHTML = marked.parse(contentText);
+        renderMarkdown(contentEl, contentText);
 
       } else if (type === 'done') {
         var finalText = contentText || reasoningText;
@@ -518,7 +539,7 @@ const Playground = (function () {
       var pct = ((count / stats.queries) * 100).toFixed(0);
       return '<div class="model-usage-item">' +
         '<span class="model-usage-dot" style="background:' + modelColor(name) + '"></span>' +
-        '<span class="model-usage-name">' + dn(name) + '</span>' +
+        '<span class="model-usage-name">' + esc(dn(name)) + '</span>' +
         '<span class="model-usage-count">' + count + ' (' + pct + '%)</span>' +
         '</div>';
     }).join('');
@@ -574,13 +595,13 @@ const Playground = (function () {
         scrollToBottom();
       }
     } catch (e) {
-      reviewContainer.innerHTML = '<div class="review-card error">Review failed: ' + e.message + '</div>';
+      reviewContainer.innerHTML = '<div class="review-card error">Review failed: ' + esc(e.message) + '</div>';
     }
 
     function handleReviewEvent(type, data) {
       if (type === 'judging') {
         reviewContainer.innerHTML = '<div class="review-card judging review-pulse">' +
-          '<span class="verdict-icon">\uD83D\uDD0D</span> ' + data.status + '</div>';
+          '<span class="verdict-icon">\uD83D\uDD0D</span> ' + esc(data.status) + '</div>';
 
       } else if (type === 'verdict') {
         var isCorrect = data.correct === true;
@@ -589,14 +610,14 @@ const Playground = (function () {
         var conf = data.confidence || 'medium';
         reviewContainer.innerHTML = '<div class="review-card ' + cls + '">' +
           '<span class="verdict-icon">' + icon + '</span> ' +
-          '<strong>' + (isCorrect ? 'Likely correct' : 'May be incorrect') + '</strong> (' + conf + ' confidence)' +
-          '<div style="margin-top:3px; font-size:10px;">' + (data.explanation || '') + '</div>' +
+          '<strong>' + (isCorrect ? 'Likely correct' : 'May be incorrect') + '</strong> (' + esc(conf) + ' confidence)' +
+          '<div style="margin-top:3px; font-size:10px;">' + esc(data.explanation || '') + '</div>' +
           '</div>';
 
       } else if (type === 'comparing') {
         comparisonDiv = document.createElement('div');
         comparisonDiv.className = 'review-card comparing review-pulse';
-        comparisonDiv.innerHTML = '<span class="verdict-icon">\uD83D\uDD04</span> ' + data.status;
+        comparisonDiv.innerHTML = '<span class="verdict-icon">\uD83D\uDD04</span> ' + esc(data.status);
         reviewContainer.appendChild(comparisonDiv);
 
       } else if (type === 'model-result') {
@@ -613,8 +634,8 @@ const Playground = (function () {
         row.innerHTML =
           '<div class="review-model-icon" style="color:' + mColor + '">' + mIcon + '</div>' +
           '<div class="review-model-info">' +
-          '<div class="review-model-name">' + (data.display_name || data.model) + '</div>' +
-          '<div class="review-model-detail">' + (data.explanation || '') + '</div>' +
+          '<div class="review-model-name">' + esc(data.display_name || data.model) + '</div>' +
+          '<div class="review-model-detail">' + esc(data.explanation || '') + '</div>' +
           '</div>';
         comparisonDiv.appendChild(row);
 
@@ -624,7 +645,7 @@ const Playground = (function () {
           comparisonDiv.classList.add(data.any_correct ? 'correct' : 'incorrect');
           var summaryDiv = document.createElement('div');
           summaryDiv.className = 'review-summary';
-          summaryDiv.innerHTML = '<strong>' + data.summary + '</strong>';
+          summaryDiv.innerHTML = '<strong>' + esc(data.summary) + '</strong>';
           comparisonDiv.appendChild(summaryDiv);
         }
       }

--- a/src/model_router_toolkit/adapters/litellm/strategy.py
+++ b/src/model_router_toolkit/adapters/litellm/strategy.py
@@ -26,6 +26,15 @@ _request_tolerance: contextvars.ContextVar[float | None] = contextvars.ContextVa
     default=None,
 )
 
+# Holds a mutable per-request slot for the routing result. A mutable dict
+# (rather than the result itself) so writes made inside copied contexts —
+# asyncio.to_thread and task groups copy the context — stay visible to the
+# request handler that installed the slot.
+_request_result: contextvars.ContextVar[dict | None] = contextvars.ContextVar(
+    "request_routing_result",
+    default=None,
+)
+
 
 class ModelRoutingStrategy:
     """Wraps a BaseRouter and implements the LiteLLM custom routing interface.
@@ -71,6 +80,21 @@ class ModelRoutingStrategy:
         """Set tolerance for the current async request context only."""
         _request_tolerance.set(max(0.0, min(1.0, value)))
 
+    def begin_request(self) -> None:
+        """Install a request-scoped slot for the routing result.
+
+        Call this in the request handler before dispatching to LiteLLM so
+        that last_result reads back this request's routing decision instead
+        of whichever concurrent request routed most recently.
+        """
+        _request_result.set({"result": None})
+
+    def _record_result(self, result: RoutingResult | None) -> None:
+        slot = _request_result.get()
+        if slot is not None:
+            slot["result"] = result
+        self._last_result = result
+
     @property
     def models(self) -> list[str] | None:
         return self._models
@@ -87,6 +111,9 @@ class ModelRoutingStrategy:
 
     @property
     def last_result(self) -> RoutingResult | None:
+        slot = _request_result.get()
+        if slot is not None:
+            return slot["result"]
         return self._last_result
 
     @property
@@ -120,7 +147,7 @@ class ModelRoutingStrategy:
         pinned = self._router.resolve(pin)
         if pinned is None:
             return None
-        self._last_result = pinned
+        self._record_result(pinned)
         return self._find_deployment(pin)
 
     def _route_and_select(
@@ -141,7 +168,7 @@ class ModelRoutingStrategy:
             text = input
 
         if not text:
-            self._last_result = None
+            self._record_result(None)
             if self._litellm_router:
                 return self._litellm_router.model_list[0]
             return {}
@@ -153,7 +180,7 @@ class ModelRoutingStrategy:
             tolerance=self.effective_tolerance,
             models=allowed,
         )
-        self._last_result = result
+        self._record_result(result)
 
         dep = self._find_deployment(result.selected_model)
         if dep:

--- a/tests/adapters/test_litellm.py
+++ b/tests/adapters/test_litellm.py
@@ -146,6 +146,51 @@ class TestModelRoutingStrategy:
         )
         assert dep["model_name"] == "model-b"
 
+    @pytest.mark.asyncio
+    async def test_last_result_is_request_scoped(self):
+        """Concurrent requests must each read back their own routing result."""
+        import asyncio
+
+        strategy = ModelRoutingStrategy(FakeRouter("model-a"), tolerance=0.20)
+        a_routed = asyncio.Event()
+        b_routed = asyncio.Event()
+
+        async def request_a():
+            strategy.begin_request()
+            await strategy.async_get_available_deployment(
+                model="x",
+                messages=[{"role": "user", "content": "q"}],
+                request_kwargs={"metadata": {"models": ["model-a"]}},
+            )
+            a_routed.set()
+            # Request B routes (and overwrites shared state) before A reads.
+            await b_routed.wait()
+            return strategy.last_result.selected_model
+
+        async def request_b():
+            await a_routed.wait()
+            strategy.begin_request()
+            await strategy.async_get_available_deployment(
+                model="x",
+                messages=[{"role": "user", "content": "q"}],
+                request_kwargs={"metadata": {"models": ["model-b"]}},
+            )
+            b_routed.set()
+            return strategy.last_result.selected_model
+
+        sel_a, sel_b = await asyncio.gather(request_a(), request_b())
+        assert sel_a == "model-a"
+        assert sel_b == "model-b"
+
+    def test_last_result_falls_back_without_begin_request(self):
+        strategy = ModelRoutingStrategy(FakeRouter("model-a"), tolerance=0.20)
+        strategy.get_available_deployment(
+            model="x",
+            messages=[{"role": "user", "content": "q"}],
+        )
+        assert strategy.last_result is not None
+        assert strategy.last_result.selected_model == "model-a"
+
     def test_pin_model_metadata_bypasses_routing(self):
         """When request_kwargs has pin_model, skip ML and return pinned model."""
         strategy = ModelRoutingStrategy(FakeRouter("model-a"), tolerance=0.20)


### PR DESCRIPTION
## Summary
Three runtime/security fixes in the serving adapters (full-mode app, router-only sidecar, and LiteLLM proxy middleware).

### 1. Playground XSS
The playground rendered streamed model output with `marked.parse()` directly into `innerHTML` with no sanitizer, and interpolated judge verdicts, model display names, confidence labels, and status strings into `innerHTML` unescaped. A model response — or a prompt-injected one — containing HTML such as `<img src=x onerror=...>` would execute script in the browser.

- Markdown is now sanitized with **DOMPurify** before insertion
- All other untrusted interpolations are HTML-escaped via a small `esc()` helper
- Both paths fall back to `textContent` if a CDN library fails to load, so raw model output is never injected

### 2. Event-loop blocking
The SSE `/api/chat` endpoint and the router-only `/v1/route` endpoint called `router.route()` — a synchronous encoder forward pass — directly on the event loop, stalling every concurrent request for its full duration. Both now dispatch through `asyncio.to_thread`, matching what the custom routing strategy already does in `async_get_available_deployment`.

### 3. Cross-request routing-result race
The strategy stored each routing decision on a single shared `_last_result` attribute. `completions.py` and the proxy response middleware read it back *after* awaiting the upstream completion to attach routing metadata / rewrite the response `model` field — so under concurrency, request A could read request B's decision and report the wrong selected model.

- The result is now held in a **request-scoped `contextvar` slot** installed via `strategy.begin_request()` (same pattern the per-request tolerance override already uses)
- `last_result` falls back to the shared attribute when no slot is installed, preserving existing single-request behavior and the library API

## Changes
- `static/playground.js`: `esc()` + `renderMarkdown()` helpers; escape/sanitize every model-, judge-, and config-derived value written to `innerHTML`
- `static/index.html`: load DOMPurify alongside marked
- `adapters/litellm/chat.py`, `adapters/http/route.py`: route via `asyncio.to_thread`
- `adapters/litellm/strategy.py`: request-scoped result slot (`begin_request()`, `_record_result()`, contextvar-aware `last_result`)
- `adapters/litellm/completions.py`, `adapters/litellm/proxy.py`: call `begin_request()` before dispatch
- Tests: concurrent requests each read back their own routing result; `last_result` still works without `begin_request()`

## Tests
- `python -m pytest tests/adapters/test_litellm.py -q` — 15 passed
- `python -m pytest -q` — 227 passed, 30 skipped; the 6 failures are pre-existing on `v3` (4 are the httpx `ASGITransport` incompatibility addressed by #26, plus environment-specific `test_gpu`/`test_trunk`)
- `python -m ruff check src/model_router_toolkit/adapters/ tests/adapters/test_litellm.py` — clean
- `node --check src/model_router_toolkit/adapters/litellm/static/playground.js` — clean
