### PR TITLE
Add opt-in request redaction middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,32 @@ model-router proxy \
 
 The proxy runs as a standard LiteLLM Proxy with the routing strategy injected at startup.
 
+#### Optional pre-cloud request redaction
+
+The in-process proxy can optionally redact common personal data from chat request text before
+LiteLLM forwards the request to an upstream provider. Redaction is disabled by default and is
+best-effort; it is not a complete privacy guarantee.
+
+```bash
+pip install -e '.[prefill,proxy,privacy]'
+python -m spacy download en_core_web_sm
+
+export MODEL_ROUTER_REDACTION_ENABLED=true
+export MODEL_ROUTER_REDACTION_BACKEND=presidio
+export MODEL_ROUTER_REDACTION_SCORE_THRESHOLD=0.35
+
+model-router proxy \
+  --litellm-config configs/litellm-proxy.yaml \
+  --router-config configs/v1-9models-qwen08b.yaml \
+  --port 4000
+```
+
+By default, the Presidio backend is limited to the initial supported entity scope: email
+addresses, phone numbers, SSNs, dates, URLs, person names, selected geographic entities,
+and organization names. Override the entity list with
+`MODEL_ROUTER_REDACTION_ENTITIES=EMAIL_ADDRESS,PHONE_NUMBER` when a deployment needs a
+narrower policy.
+
 **When to use**: Production deployments, teams already using LiteLLM, environments needing auth/rate-limiting/caching.
 
 ### LiteLLM Proxy + External Sidecar Hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ proxy = [
     "litellm[proxy]>=1.50,<=1.82.6",
     "packaging>=20.0",
 ]
+privacy = [
+    "presidio-analyzer>=2.2,<3",
+    "presidio-anonymizer>=2.2,<3",
+    "spacy>=3.7,<4",
+]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",

--- a/src/model_router_toolkit/adapters/litellm/proxy.py
+++ b/src/model_router_toolkit/adapters/litellm/proxy.py
@@ -100,11 +100,12 @@ def start_proxy(
 
     os.environ["CONFIG_FILE_PATH"] = litellm_config
 
+    from litellm.proxy.proxy_server import app as litellm_app
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.requests import Request
     from starlette.responses import Response
 
-    from litellm.proxy.proxy_server import app as litellm_app
+    from model_router_toolkit.privacy.middleware import maybe_add_request_redaction_middleware
 
     _strategy_ref = None
 
@@ -159,6 +160,7 @@ def start_proxy(
             return response
 
     litellm_app.add_middleware(_RouterProxyMiddleware)
+    maybe_add_request_redaction_middleware(litellm_app)
 
     import uvicorn
 

--- a/src/model_router_toolkit/privacy/__init__.py
+++ b/src/model_router_toolkit/privacy/__init__.py
@@ -1,0 +1,1 @@
+"""Privacy helpers for request-time redaction."""

--- a/src/model_router_toolkit/privacy/middleware.py
+++ b/src/model_router_toolkit/privacy/middleware.py
@@ -1,0 +1,140 @@
+"""ASGI middleware for redacting cloud-bound JSON request bodies."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Awaitable, Callable, Mapping
+
+from model_router_toolkit.privacy.redaction import (
+    RedactionConfig,
+    TextRedactor,
+    create_text_redactor,
+    redact_json_request_body,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PATHS = frozenset({"/v1/chat/completions"})
+
+Scope = dict[str, object]
+Message = dict[str, object]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+
+
+class RequestRedactionMiddleware:
+    """Redact OpenAI-compatible chat JSON before downstream proxy handling."""
+
+    def __init__(
+        self,
+        app: Callable[[Scope, Receive, Send], Awaitable[None]],
+        *,
+        redactor: TextRedactor,
+        fail_open: bool = True,
+        paths: frozenset[str] = _DEFAULT_PATHS,
+    ):
+        self.app = app
+        self._redactor = redactor
+        self._fail_open = fail_open
+        self._paths = paths
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self._should_redact(scope):
+            await self.app(scope, receive, send)
+            return
+
+        original_body = await _read_body(receive)
+        try:
+            redacted_body, changed = redact_json_request_body(original_body, self._redactor)
+        except Exception:
+            logger.exception("Request redaction failed")
+            if not self._fail_open:
+                raise
+            redacted_body = original_body
+            changed = False
+
+        next_body = redacted_body if changed else original_body
+        await self.app(_with_content_length(scope, len(next_body)), _receive_once(next_body), send)
+
+    def _should_redact(self, scope: Scope) -> bool:
+        if scope.get("type") != "http":
+            return False
+        if str(scope.get("method", "")).upper() != "POST":
+            return False
+        if scope.get("path") not in self._paths:
+            return False
+        return "application/json" in _header_value(scope, b"content-type")
+
+
+def maybe_add_request_redaction_middleware(
+    app,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """Install request redaction middleware when enabled by environment."""
+
+    config = RedactionConfig.from_env(env or os.environ)
+    if not config.enabled:
+        return False
+
+    redactor = create_text_redactor(config)
+    app.add_middleware(
+        RequestRedactionMiddleware,
+        redactor=redactor,
+        fail_open=config.fail_open,
+    )
+    logger.info("Request redaction middleware enabled with backend %s", config.backend)
+    return True
+
+
+async def _read_body(receive: Receive) -> bytes:
+    chunks: list[bytes] = []
+    more_body = True
+    while more_body:
+        message = await receive()
+        body = message.get("body", b"")
+        if isinstance(body, bytes):
+            chunks.append(body)
+        more_body = bool(message.get("more_body", False))
+    return b"".join(chunks)
+
+
+def _receive_once(body: bytes) -> Receive:
+    sent = False
+
+    async def receive() -> Message:
+        nonlocal sent
+        if sent:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+def _header_value(scope: Scope, header_name: bytes) -> str:
+    headers = scope.get("headers") or []
+    if not isinstance(headers, list):
+        return ""
+    for key, value in headers:
+        if key.lower() == header_name and isinstance(value, bytes):
+            return value.decode("latin1").lower()
+    return ""
+
+
+def _with_content_length(scope: Scope, body_length: int) -> Scope:
+    next_scope = dict(scope)
+    next_scope["headers"] = _replace_content_length(scope.get("headers", []), body_length)
+    return next_scope
+
+
+def _replace_content_length(
+    headers: object,
+    body_length: int,
+) -> list[tuple[bytes, bytes]]:
+    if not isinstance(headers, list):
+        headers = []
+    next_headers = [(key, value) for key, value in headers if key.lower() != b"content-length"]
+    next_headers.append((b"content-length", str(body_length).encode("ascii")))
+    return next_headers

--- a/src/model_router_toolkit/privacy/redaction.py
+++ b/src/model_router_toolkit/privacy/redaction.py
@@ -1,0 +1,220 @@
+"""Best-effort request text redaction for cloud-bound inference calls."""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PRESIDIO_ENTITIES: tuple[str, ...] = (
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_SSN",
+    "DATE_TIME",
+    "URL",
+    "PERSON",
+    "LOCATION",
+    "ORGANIZATION",
+)
+
+
+class TextRedactor(Protocol):
+    """Minimal interface implemented by request redaction backends."""
+
+    def redact_text(self, text: str) -> str:
+        """Return ``text`` with sensitive spans replaced."""
+
+
+class NoopRedactor:
+    """Redactor that preserves text exactly."""
+
+    def redact_text(self, text: str) -> str:
+        return text
+
+
+@dataclass(frozen=True)
+class RedactionConfig:
+    """Environment-driven redaction settings."""
+
+    enabled: bool = False
+    backend: str = "presidio"
+    score_threshold: float = 0.35
+    entities: tuple[str, ...] | None = DEFAULT_PRESIDIO_ENTITIES
+    language: str = "en"
+    fail_open: bool = True
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str]) -> RedactionConfig:
+        enabled_value = env.get("MODEL_ROUTER_REDACTION_ENABLED", "")
+        legacy_value = env.get("MODEL_ROUTER_REDACTION", "")
+        enabled = _parse_bool(enabled_value or legacy_value, default=False)
+        backend = (env.get("MODEL_ROUTER_REDACTION_BACKEND") or "presidio").strip().lower()
+        score_threshold = _parse_float(
+            env.get("MODEL_ROUTER_REDACTION_SCORE_THRESHOLD"),
+            default=0.35,
+        )
+        entities = (
+            _parse_entities(env.get("MODEL_ROUTER_REDACTION_ENTITIES"))
+            or DEFAULT_PRESIDIO_ENTITIES
+        )
+        language = (env.get("MODEL_ROUTER_REDACTION_LANGUAGE") or "en").strip() or "en"
+        fail_open = _parse_bool(env.get("MODEL_ROUTER_REDACTION_FAIL_OPEN"), default=True)
+        return cls(
+            enabled=enabled,
+            backend=backend,
+            score_threshold=score_threshold,
+            entities=entities,
+            language=language,
+            fail_open=fail_open,
+        )
+
+
+class PresidioRedactor:
+    """Presidio-backed text redactor.
+
+    Presidio is imported lazily so deployments that do not enable redaction do
+    not need the optional privacy dependencies installed.
+    """
+
+    def __init__(
+        self,
+        *,
+        score_threshold: float = 0.35,
+        entities: tuple[str, ...] | None = None,
+        language: str = "en",
+    ):
+        try:
+            from presidio_analyzer import AnalyzerEngine
+            from presidio_anonymizer import AnonymizerEngine
+            from presidio_anonymizer.entities import OperatorConfig
+        except ImportError as exc:
+            raise RuntimeError(
+                "Presidio redaction requires optional privacy dependencies. "
+                "Install model-router-toolkit[privacy] and a compatible spaCy model."
+            ) from exc
+
+        self._analyzer = AnalyzerEngine()
+        self._anonymizer = AnonymizerEngine()
+        self._operator_config = OperatorConfig("replace", {"new_value": "<PII>"})
+        self._score_threshold = score_threshold
+        self._entities = list(entities or DEFAULT_PRESIDIO_ENTITIES)
+        self._language = language
+
+    def redact_text(self, text: str) -> str:
+        if not text:
+            return text
+        results = self._analyzer.analyze(
+            text=text,
+            language=self._language,
+            entities=self._entities,
+            score_threshold=self._score_threshold,
+        )
+        if not results:
+            return text
+        anonymized = self._anonymizer.anonymize(
+            text=text,
+            analyzer_results=results,
+            operators={"DEFAULT": self._operator_config},
+        )
+        return anonymized.text
+
+
+def create_text_redactor(config: RedactionConfig) -> TextRedactor:
+    """Create the configured redaction backend."""
+
+    if not config.enabled:
+        return NoopRedactor()
+    if config.backend == "presidio":
+        return PresidioRedactor(
+            score_threshold=config.score_threshold,
+            entities=config.entities,
+            language=config.language,
+        )
+    raise ValueError(f"Unsupported redaction backend: {config.backend}")
+
+
+def redact_openai_chat_payload(payload: Any, redactor: TextRedactor) -> Any:
+    """Redact text-bearing fields in an OpenAI-compatible chat payload.
+
+    The traversal intentionally limits itself to request text content. It does
+    not rewrite tools, function schemas, images, or arbitrary metadata.
+    """
+
+    redacted = copy.deepcopy(payload)
+    if not isinstance(redacted, dict):
+        return redacted
+
+    messages = redacted.get("messages")
+    if isinstance(messages, list):
+        for message in messages:
+            _redact_message_content(message, redactor)
+
+    return redacted
+
+
+def redact_json_request_body(body: bytes, redactor: TextRedactor) -> tuple[bytes, bool]:
+    """Return a redacted JSON request body and whether it changed."""
+
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return body, False
+
+    redacted = redact_openai_chat_payload(payload, redactor)
+    if redacted == payload:
+        return body, False
+    return json.dumps(redacted, separators=(",", ":"), ensure_ascii=False).encode("utf-8"), True
+
+
+def _redact_message_content(message: Any, redactor: TextRedactor) -> None:
+    if not isinstance(message, dict):
+        return
+
+    content = message.get("content")
+    if isinstance(content, str):
+        message["content"] = redactor.redact_text(content)
+        return
+
+    if not isinstance(content, list):
+        return
+
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "text" and isinstance(part.get("text"), str):
+            part["text"] = redactor.redact_text(part["text"])
+
+
+def _parse_bool(value: str | None, *, default: bool) -> bool:
+    if value is None or value == "":
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on", "presidio"}:
+        return True
+    if normalized in {"0", "false", "no", "off", "none", "noop"}:
+        return False
+    logger.warning("Unrecognized redaction boolean %r; using default %s", value, default)
+    return default
+
+
+def _parse_float(value: str | None, *, default: float) -> float:
+    if value is None or value.strip() == "":
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        logger.warning("Invalid redaction score threshold %r; using %.2f", value, default)
+        return default
+    return max(0.0, min(1.0, parsed))
+
+
+def _parse_entities(value: str | None) -> tuple[str, ...] | None:
+    if value is None or value.strip() == "":
+        return None
+    entities = tuple(entity.strip() for entity in value.split(",") if entity.strip())
+    return entities or None

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,134 @@
+import json
+
+from model_router_toolkit.privacy.redaction import (
+    NoopRedactor,
+    RedactionConfig,
+    redact_json_request_body,
+    redact_openai_chat_payload,
+)
+
+
+class RecordingRedactor:
+    def __init__(self):
+        self.seen: list[str] = []
+
+    def redact_text(self, text: str) -> str:
+        self.seen.append(text)
+        return f"<redacted:{len(self.seen)}>"
+
+
+def test_redaction_config_is_disabled_by_default():
+    config = RedactionConfig.from_env({})
+
+    assert config.enabled is False
+    assert config.backend == "presidio"
+    assert config.score_threshold == 0.35
+    assert config.fail_open is True
+
+
+def test_redaction_config_uses_limited_default_entity_scope():
+    config = RedactionConfig.from_env(
+        {
+            "MODEL_ROUTER_REDACTION_ENABLED": "true",
+        }
+    )
+
+    assert config.entities == (
+        "EMAIL_ADDRESS",
+        "PHONE_NUMBER",
+        "US_SSN",
+        "DATE_TIME",
+        "URL",
+        "PERSON",
+        "LOCATION",
+        "ORGANIZATION",
+    )
+
+
+def test_redaction_config_parses_enabled_presidio_settings():
+    config = RedactionConfig.from_env(
+        {
+            "MODEL_ROUTER_REDACTION_ENABLED": "true",
+            "MODEL_ROUTER_REDACTION_BACKEND": "presidio",
+            "MODEL_ROUTER_REDACTION_SCORE_THRESHOLD": "0.5",
+            "MODEL_ROUTER_REDACTION_ENTITIES": "EMAIL_ADDRESS,PHONE_NUMBER",
+            "MODEL_ROUTER_REDACTION_FAIL_OPEN": "false",
+        }
+    )
+
+    assert config.enabled is True
+    assert config.backend == "presidio"
+    assert config.score_threshold == 0.5
+    assert config.entities == ("EMAIL_ADDRESS", "PHONE_NUMBER")
+    assert config.fail_open is False
+
+
+def test_redact_openai_chat_payload_only_rewrites_text_content():
+    payload = {
+        "model": "nvidia-routed",
+        "messages": [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "Email ada@example.com before calling."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Call +1 555 0100."},
+                    {"type": "image_url", "image_url": {"url": "https://example.test/a.png"}},
+                ],
+            },
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "send_email",
+                    "description": "Send email to the address requested by the user.",
+                },
+            }
+        ],
+    }
+    redactor = RecordingRedactor()
+
+    redacted = redact_openai_chat_payload(payload, redactor)
+
+    assert redacted["messages"][0]["content"] == "<redacted:1>"
+    assert redacted["messages"][1]["content"] == "<redacted:2>"
+    assert redacted["messages"][2]["content"][0]["text"] == "<redacted:3>"
+    assert redacted["messages"][2]["content"][1]["image_url"]["url"] == "https://example.test/a.png"
+    assert redacted["tools"] == payload["tools"]
+    assert payload["messages"][1]["content"] == "Email ada@example.com before calling."
+    assert redactor.seen == [
+        "You are concise.",
+        "Email ada@example.com before calling.",
+        "Call +1 555 0100.",
+    ]
+
+
+def test_noop_redactor_leaves_payload_equal():
+    payload = {"messages": [{"role": "user", "content": "Email ada@example.com"}]}
+
+    redacted = redact_openai_chat_payload(payload, NoopRedactor())
+
+    assert redacted == payload
+    assert redacted is not payload
+
+
+def test_redact_json_request_body_rewrites_valid_json_body():
+    body = json.dumps(
+        {"messages": [{"role": "user", "content": "My SSN is 123-45-6789."}]}
+    ).encode()
+    redactor = RecordingRedactor()
+
+    redacted_body, changed = redact_json_request_body(body, redactor)
+
+    assert changed is True
+    assert json.loads(redacted_body) == {
+        "messages": [{"role": "user", "content": "<redacted:1>"}]
+    }
+
+
+def test_redact_json_request_body_ignores_invalid_json():
+    redacted_body, changed = redact_json_request_body(b"not-json", RecordingRedactor())
+
+    assert changed is False
+    assert redacted_body == b"not-json"

--- a/tests/test_redaction_middleware.py
+++ b/tests/test_redaction_middleware.py
@@ -1,0 +1,94 @@
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from model_router_toolkit.privacy.middleware import (
+    RequestRedactionMiddleware,
+    maybe_add_request_redaction_middleware,
+)
+
+
+class StaticRedactor:
+    def redact_text(self, text: str) -> str:
+        return "<PII>"
+
+
+class FailingRedactor:
+    def redact_text(self, text: str) -> str:
+        raise RuntimeError("redactor unavailable")
+
+
+async def echo_json(request: Request) -> JSONResponse:
+    return JSONResponse(await request.json())
+
+
+def build_app(redactor, *, fail_open: bool = True) -> Starlette:
+    app = Starlette(
+        routes=[Route("/v1/chat/completions", echo_json, methods=["POST"])],
+    )
+    app.add_middleware(
+        RequestRedactionMiddleware,
+        redactor=redactor,
+        fail_open=fail_open,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_request_redaction_middleware_rewrites_chat_body_before_downstream():
+    app = build_app(StaticRedactor())
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "Email ada@example.com"}]},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"messages": [{"role": "user", "content": "<PII>"}]}
+
+
+@pytest.mark.asyncio
+async def test_request_redaction_middleware_fails_open_by_default():
+    app = build_app(FailingRedactor(), fail_open=True)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "Email ada@example.com"}]},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "messages": [{"role": "user", "content": "Email ada@example.com"}]
+    }
+
+
+def test_maybe_add_request_redaction_middleware_skips_disabled_config():
+    app = Starlette()
+
+    installed = maybe_add_request_redaction_middleware(app, env={})
+
+    assert installed is False
+    assert app.user_middleware == []
+
+
+def test_maybe_add_request_redaction_middleware_installs_enabled_config(monkeypatch):
+    app = Starlette()
+    monkeypatch.setattr(
+        "model_router_toolkit.privacy.middleware.create_text_redactor",
+        lambda _config: StaticRedactor(),
+    )
+
+    installed = maybe_add_request_redaction_middleware(
+        app,
+        env={"MODEL_ROUTER_REDACTION_ENABLED": "true"},
+    )
+
+    assert installed is True
+    assert len(app.user_middleware) == 1


### PR DESCRIPTION
## Summary

Adds an opt-in local request redaction layer for the in-process LiteLLM proxy path.
When enabled, `/v1/chat/completions` JSON request bodies are redacted before LiteLLM forwards them to an upstream provider.

The feature is disabled by default and uses a lazy Presidio backend so existing proxy deployments do not need the optional privacy dependencies unless redaction is explicitly enabled.

The initial default Presidio entity scope is intentionally narrow:

- email addresses
- phone numbers
- US SSNs
- dates and dates of birth
- URLs
- person names
- selected geographic entities
- organization and company names

## Motivation

The router already sits on the host-side path between local clients and upstream model providers. This change adds a best-effort data minimization hook at that boundary for common prompt-level personal data, while preserving current behavior when the feature is not enabled.

## Design

- Adds a `model-router-toolkit[privacy]` optional extra for Presidio dependencies.
- Adds a small `privacy` module with:
  - environment-driven redaction config
  - no-op backend for default behavior
  - lazy Presidio backend
  - OpenAI-compatible chat payload traversal
  - ASGI middleware for `/v1/chat/completions`
- Installs the middleware from the in-process LiteLLM proxy only when `MODEL_ROUTER_REDACTION_ENABLED=true`.
- Preserves request JSON structure and only rewrites text-bearing chat message content.
- Leaves tools, function schemas, images, and arbitrary metadata untouched.

## Evaluation context

I evaluated Presidio separately on the first 5,000 examples from `nvidia/Nemotron-PII` test split using `en_core_web_sm` and threshold `0.35`. For the comparable entity subset aligned with this PR scope:

- character recall: 0.8837
- character F1: 0.6918
- span overlap recall: 0.9821
- full span coverage recall: 0.8313

Selected full span coverage recall:

| Label | Full coverage recall |
| --- | ---: |
| email | 0.9972 |
| phone_number | 0.9964 |
| ssn | 0.9974 |
| date_of_birth | 1.0000 |
| date | 0.9327 |
| first_name | 0.8470 |
| last_name | 0.8565 |
| city | 0.8142 |
| county | 0.8932 |

This is why the initial default scope is limited to common entities where Presidio is useful as a local best-effort backend.

## Non-goals

This PR does not claim complete PII protection. It does not add query-aware minimization, output de-anonymization, broad sensitive attribute classification, or custom recognizers for credentials/API keys.

## Validation

- `pytest tests/test_redaction.py tests/test_redaction_middleware.py -q`
  - `11 passed in 0.11s`
- `python -m ruff check src/model_router_toolkit/privacy src/model_router_toolkit/adapters/litellm/proxy.py tests/test_redaction.py tests/test_redaction_middleware.py`
  - `All checks passed!`

I also tried a broader local run with `pytest -q -m "not slow and not requires_torch"`; it failed on pre-existing environment/tooling issues unrelated to this diff: `httpx.AsyncClient(app=...)` incompatibility and `nvidia-smi` returning `[N/A]` for GPU memory on this server.
