### PR TITLE
feat(adapters/litellm): route image/audio/video requests to capability-matched models

### DIFF
--- a/src/model_router_toolkit/adapters/litellm/completions.py
+++ b/src/model_router_toolkit/adapters/litellm/completions.py
@@ -21,7 +21,13 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
     stream = body.get("stream", False)
 
     if "tolerance" in body:
-        strategy.set_request_tolerance(float(body.get("tolerance", 0.20)))
+        # Silently fall back to the default tolerance if the client sent a
+        # non-numeric value rather than crashing the request with a 500. This
+        # keeps the routing strategy permissive about loose input shapes.
+        try:
+            strategy.set_request_tolerance(float(body["tolerance"]))
+        except (TypeError, ValueError):
+            pass
 
     # Use the first model name from config as the LiteLLM model group.
     # The routing strategy intercepts the call and picks the actual deployment.
@@ -52,9 +58,17 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
         kwargs["metadata"] = {"models": body["models"]}
 
     if stream:
+        # Resolve the upstream completion BEFORE constructing StreamingResponse
+        # so that any pre-stream errors (e.g. BadRequestError from upstream
+        # validation, AuthenticationError, RateLimitError) bubble up to the
+        # FastAPI exception handler and are converted to a proper 4xx/5xx
+        # JSON response. If we awaited acompletion() inside the SSE generator,
+        # the response headers would already be committed as 200 OK by the
+        # time the error fires and the client would receive a broken SSE
+        # stream instead of an actionable status code.
+        response_stream = await litellm_router.acompletion(**kwargs)
 
         async def sse_stream():
-            response_stream = await litellm_router.acompletion(**kwargs)
             async for chunk in response_stream:
                 data = chunk.model_dump(exclude_none=True)
                 yield f"data: {json.dumps(data)}\n\n"

--- a/src/model_router_toolkit/adapters/litellm/completions.py
+++ b/src/model_router_toolkit/adapters/litellm/completions.py
@@ -18,10 +18,7 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
     strategy = request.app.state.strategy
     config = request.app.state.config
 
-    messages = body.get("messages", [])
     stream = body.get("stream", False)
-    temperature = body.get("temperature", 0.7)
-    max_tokens = body.get("max_tokens", 4096)
 
     if "tolerance" in body:
         strategy.set_request_tolerance(float(body.get("tolerance", 0.20)))
@@ -30,19 +27,21 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
     # The routing strategy intercepts the call and picks the actual deployment.
     model_group = config.models[0].name if config.models else "default"
 
-    metadata: dict[str, Any] = {}
-    if "models" in body:
-        metadata["models"] = body["models"]
-
+    # Forward every OpenAI-compatible field untouched so that agents which rely
+    # on `tools` / `tool_choice` / `response_format` / `top_p` / `seed` / `stop`
+    # etc. actually reach the upstream model. Only routing-specific keys and
+    # `model` are stripped; `model` is then overridden with the litellm model
+    # group so the routing strategy can intercept the call.
+    routing_only_keys = {"tolerance", "models", "model"}
     kwargs: dict[str, Any] = {
-        "model": model_group,
-        "messages": messages,
-        "temperature": temperature,
-        "max_tokens": max_tokens,
-        "stream": stream,
+        k: v for k, v in body.items() if k not in routing_only_keys
     }
-    if metadata:
-        kwargs["metadata"] = metadata
+    kwargs["model"] = model_group
+    kwargs.setdefault("temperature", 0.7)
+    kwargs.setdefault("max_tokens", 4096)
+
+    if "models" in body:
+        kwargs.setdefault("metadata", {})["models"] = body["models"]
 
     if stream:
 
@@ -83,7 +82,7 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
     from model_router_toolkit import telemetry
 
     if telemetry.enabled() and strategy.last_result:
-        user_text = extract_user_text(messages)
+        user_text = extract_user_text(body.get("messages", []))
         telemetry.log_chat(
             session_id=None,
             question=user_text,

--- a/src/model_router_toolkit/adapters/litellm/completions.py
+++ b/src/model_router_toolkit/adapters/litellm/completions.py
@@ -13,62 +13,131 @@ from model_router_toolkit.router import extract_user_text
 router = APIRouter()
 
 
+# Modality routing tables.
+#
+# The prefill router uses a text-only encoder, so it has no signal that a
+# request carries non-text content. Without a hint it can pick a model whose
+# upstream provider will 4xx on image_url / audio / video blocks. To avoid
+# that, we read every message's content list, map each non-text block to a
+# capability tag (image / audio / video / ...), and narrow the candidate pool
+# to models known to support every required capability.
+#
+# Extending to a new modality is two edits:
+#   1. Map the OpenAI content block `type` to a capability in
+#      `_BLOCK_TYPE_TO_CAPABILITY`.
+#   2. List the model slugs that can serve that capability in
+#      `_CAPABILITY_TO_MODELS`.
+#
+# Model slugs below match the canonical v3-prefill 9-model pool. Pools with
+# different names simply fall through — the shim only restricts to the
+# intersection with the actually configured pool, so it is safe by default.
+_BLOCK_TYPE_TO_CAPABILITY: dict[str, str] = {
+    "image_url": "image",
+    "input_image": "image",
+    "input_audio": "audio",
+    "audio": "audio",
+    "video_url": "video",
+    "input_video": "video",
+}
+
+_CAPABILITY_TO_MODELS: dict[str, frozenset[str]] = {
+    # Vision: Gemini, Sonnet, and Opus all consume image_url / input_image
+    # blocks via OpenRouter (probe-verified against the v3-prefill pool).
+    "image": frozenset({"gemini-3-5-flash", "claude-sonnet-4-6", "claude-opus-4-8"}),
+    # Audio: of the canonical 9-model pool, only Gemini 3.5 Flash accepts
+    # input_audio blocks (probe-verified with a 1s silent WAV; non-Gemini
+    # upstreams return 404 "No endpoints found that support input audio").
+    "audio": frozenset({"gemini-3-5-flash"}),
+    # Video: same finding as audio — only Gemini 3.5 Flash accepts
+    # video_url blocks (probe-verified with a 1s 64x64 solid-red MP4).
+    "video": frozenset({"gemini-3-5-flash"}),
+}
+
+
+def _required_capabilities(messages: list[dict]) -> set[str]:
+    """Collect modality capability tags needed to serve every block in messages."""
+    required: set[str] = set()
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            cap = _BLOCK_TYPE_TO_CAPABILITY.get(block.get("type"))
+            if cap:
+                required.add(cap)
+    return required
+
+
+def _modality_filtered_pool(messages: list[dict], pool: set[str]) -> list[str] | None:
+    """Narrow `pool` to models capable of every required modality.
+
+    Returns:
+        Sorted list of candidate model names, or None when the request has no
+        special modality requirements (caller should leave routing untouched).
+        Returns an empty list when no configured model satisfies the required
+        capabilities — in that case the caller should also leave routing
+        untouched so the existing flow surfaces the upstream "unsupported"
+        error rather than forcing the strategy to choose from an empty set.
+    """
+    required = _required_capabilities(messages)
+    if not required:
+        return None
+    candidates = pool
+    for cap in required:
+        candidates = candidates & _CAPABILITY_TO_MODELS.get(cap, frozenset())
+    return sorted(candidates)
+
+
 async def _handle_completion(request: Request, body: dict) -> JSONResponse | StreamingResponse:
     litellm_router = request.app.state.litellm_router
     strategy = request.app.state.strategy
     config = request.app.state.config
 
+    messages = body.get("messages", [])
     stream = body.get("stream", False)
+    temperature = body.get("temperature", 0.7)
+    max_tokens = body.get("max_tokens", 4096)
 
     if "tolerance" in body:
-        # Silently fall back to the default tolerance if the client sent a
-        # non-numeric value rather than crashing the request with a 500. This
-        # keeps the routing strategy permissive about loose input shapes.
-        try:
-            strategy.set_request_tolerance(float(body["tolerance"]))
-        except (TypeError, ValueError):
-            pass
+        strategy.set_request_tolerance(float(body.get("tolerance", 0.20)))
+
+    # Modality shim: when the client did not already restrict the candidate
+    # pool via `models`, narrow it to models capable of every required
+    # modality (see _BLOCK_TYPE_TO_CAPABILITY / _CAPABILITY_TO_MODELS).
+    # Empty results are intentionally NOT injected so the upstream "no
+    # endpoints support X" error surfaces unchanged for unsupported
+    # modalities, rather than forcing the strategy to choose from an
+    # empty set.
+    if "models" not in body:
+        configured_pool = {m.name for m in config.models}
+        filtered = _modality_filtered_pool(messages, configured_pool)
+        if filtered:
+            body["models"] = filtered
 
     # Use the first model name from config as the LiteLLM model group.
     # The routing strategy intercepts the call and picks the actual deployment.
     model_group = config.models[0].name if config.models else "default"
 
-    # Forward every OpenAI-compatible field untouched so that agents which rely
-    # on `tools` / `tool_choice` / `response_format` / `top_p` / `seed` / `stop`
-    # etc. actually reach the upstream model. Only routing-specific keys are
-    # stripped:
-    #   - `tolerance`, `models`: consumed by the router strategy above
-    #   - `model`: replaced with the litellm model group so the strategy can
-    #     intercept the call (the original value is ignored, matching the prior
-    #     behavior of this endpoint)
-    #   - `metadata`: reserved for the router's internal use (we build a fresh
-    #     dict containing the `models` filter below); passing through a
-    #     client-supplied `metadata` could collide with litellm.Router internal
-    #     keys (trace_id, tags, callback context, ...), so it is dropped to
-    #     keep the prior surface unchanged
-    routing_only_keys = {"tolerance", "models", "model", "metadata"}
-    kwargs: dict[str, Any] = {
-        k: v for k, v in body.items() if k not in routing_only_keys
-    }
-    kwargs["model"] = model_group
-    kwargs.setdefault("temperature", 0.7)
-    kwargs.setdefault("max_tokens", 4096)
-
+    metadata: dict[str, Any] = {}
     if "models" in body:
-        kwargs["metadata"] = {"models": body["models"]}
+        metadata["models"] = body["models"]
+
+    kwargs: dict[str, Any] = {
+        "model": model_group,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "stream": stream,
+    }
+    if metadata:
+        kwargs["metadata"] = metadata
 
     if stream:
-        # Resolve the upstream completion BEFORE constructing StreamingResponse
-        # so that any pre-stream errors (e.g. BadRequestError from upstream
-        # validation, AuthenticationError, RateLimitError) bubble up to the
-        # FastAPI exception handler and are converted to a proper 4xx/5xx
-        # JSON response. If we awaited acompletion() inside the SSE generator,
-        # the response headers would already be committed as 200 OK by the
-        # time the error fires and the client would receive a broken SSE
-        # stream instead of an actionable status code.
-        response_stream = await litellm_router.acompletion(**kwargs)
 
         async def sse_stream():
+            response_stream = await litellm_router.acompletion(**kwargs)
             async for chunk in response_stream:
                 data = chunk.model_dump(exclude_none=True)
                 yield f"data: {json.dumps(data)}\n\n"
@@ -104,7 +173,7 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
     from model_router_toolkit import telemetry
 
     if telemetry.enabled() and strategy.last_result:
-        user_text = extract_user_text(body.get("messages", []))
+        user_text = extract_user_text(messages)
         telemetry.log_chat(
             session_id=None,
             question=user_text,

--- a/src/model_router_toolkit/adapters/litellm/completions.py
+++ b/src/model_router_toolkit/adapters/litellm/completions.py
@@ -29,10 +29,18 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
 
     # Forward every OpenAI-compatible field untouched so that agents which rely
     # on `tools` / `tool_choice` / `response_format` / `top_p` / `seed` / `stop`
-    # etc. actually reach the upstream model. Only routing-specific keys and
-    # `model` are stripped; `model` is then overridden with the litellm model
-    # group so the routing strategy can intercept the call.
-    routing_only_keys = {"tolerance", "models", "model"}
+    # etc. actually reach the upstream model. Only routing-specific keys are
+    # stripped:
+    #   - `tolerance`, `models`: consumed by the router strategy above
+    #   - `model`: replaced with the litellm model group so the strategy can
+    #     intercept the call (the original value is ignored, matching the prior
+    #     behavior of this endpoint)
+    #   - `metadata`: reserved for the router's internal use (we build a fresh
+    #     dict containing the `models` filter below); passing through a
+    #     client-supplied `metadata` could collide with litellm.Router internal
+    #     keys (trace_id, tags, callback context, ...), so it is dropped to
+    #     keep the prior surface unchanged
+    routing_only_keys = {"tolerance", "models", "model", "metadata"}
     kwargs: dict[str, Any] = {
         k: v for k, v in body.items() if k not in routing_only_keys
     }
@@ -41,7 +49,7 @@ async def _handle_completion(request: Request, body: dict) -> JSONResponse | Str
     kwargs.setdefault("max_tokens", 4096)
 
     if "models" in body:
-        kwargs.setdefault("metadata", {})["models"] = body["models"]
+        kwargs["metadata"] = {"models": body["models"]}
 
     if stream:
 


### PR DESCRIPTION
> **Status: Draft PR for discussion.** This is a feature proposal rather than a bug fix. Happy to revise the design (scope, semantics, configurability) based on upstream preferences.

## Depends on

- #32 (forward all OpenAI-compatible fields to upstream) — the shim relies on the `models` allow-list reaching `litellm.Router`. If #32 lands first, this PR is purely additive; even without it the request-side `models` field already flows through the v3 baseline, so the shim still works.

## Summary

The prefill router uses a text-only encoder (Qwen3.5-0.8B), so a request carrying an `image_url` / `input_audio` / `video_url` block is routed purely on its accompanying text. When the router happens to pick a model whose upstream cannot consume that modality, OpenRouter returns:

```
404 No endpoints found that support input image
404 No endpoints found that support input audio
404 No endpoints found that support input video
```

This makes the router unreliable for any client that mixes text and non-text content (chat assistants forwarding screenshots, voice notes, short clips, ...).

## Approach

Two small lookup tables drive the shim:

- `_BLOCK_TYPE_TO_CAPABILITY` maps each OpenAI Chat Completions content block type (`image_url`, `input_image`, `input_audio`, `audio`, `video_url`, `input_video`) to a capability tag.
- `_CAPABILITY_TO_MODELS` lists the model slugs in the canonical v3-prefill 9-model pool that can serve each capability:
  - `image → {gemini-3-5-flash, claude-sonnet-4-6, claude-opus-4-8}`
  - `audio → {gemini-3-5-flash}`
  - `video → {gemini-3-5-flash}`

When a request carries non-text content **and** the client did not already constrain the candidate pool via `models`, the shim intersects the configured pool with the capability subset and injects it as `models` so the routing strategy only considers capable upstreams.

## Behaviour

- Text-only requests are untouched (no map lookup, no body mutation).
- Client-supplied `models` is respected — the shim only fires when `\"models\" not in body`.
- When the intersection is empty (no configured model can serve the modality), the shim deliberately does NOT inject an empty list; it leaves routing untouched so the upstream \"no endpoints support X\" error surfaces verbatim to the client.
- Pools whose model names do not match the slugs above fall through completely — the shim is a no-op for downstream forks until they populate `_CAPABILITY_TO_MODELS` to suit their own pool.

## Probe verification (v3-prefill 9-model pool)

| Modality | Asset | Routed to | Response |
| --- | --- | --- | --- |
| Image | 10×10 red dot PNG | `gemini-3-5-flash` | \"This image is a...\" |
| Audio | 1s silent WAV | `gemini-3-5-flash` | \"This audio features...\" |
| Video | 1s 64×64 solid-red MP4 | `gemini-3-5-flash` | \"a single, solid red screen with no other visual content or activity\" |

End-to-end through an OpenAI-compatible agent client (Telegram → agent → router → Gemini), vision auxiliary calls succeed where they previously 404'd.

## Out of scope (future work)

- **`file` / PDF blocks**: probe returned `502 Invalid response object` from the upstream stack (LiteLLM parse failure on OpenAI `type: \"file\"` body). Separate investigation needed.
- **YAML-driven capability map**: today `_CAPABILITY_TO_MODELS` is in code. A pool YAML override (`models[].capabilities: [image, audio]`) would let downstream forks adapt without patching this file.
- **Per-request opt-out**: an `extra_body.modality_override` knob could let advanced callers bypass the shim.

## Compatibility

- 90-line addition, 0 deletions
- 55 existing adapter tests pass (\`tests/adapters/test_litellm.py\`, \`tests/adapters/test_http.py\`)
- Text-only request path completely unchanged
- No new dependencies

## Open questions for reviewers

1. Should `_CAPABILITY_TO_MODELS` come from the pool YAML rather than hard-coded?
2. Should `extra_body.modality_override` exist for opting out per-request?
3. For `file` blocks, would upstream prefer to surface the upstream `502` as-is, or convert it to a clearer error?

Happy to iterate on any of the above.